### PR TITLE
Fix #159 (RDP)

### DIFF
--- a/InnovatorAdmin/Editor/EditorWinForm.cs
+++ b/InnovatorAdmin/Editor/EditorWinForm.cs
@@ -753,6 +753,7 @@ namespace InnovatorAdmin.Editor
 
       public void AutoGrow()
       {
+        if (null == this.CompletionList.ScrollViewer) return;
         var addition = this.CompletionList.ScrollViewer.ExtentWidth - this.CompletionList.ScrollViewer.ViewportWidth;
         var client = this.TextArea.PointFromScreen(new System.Windows.Point(this.Left, this.Top));
         addition = Math.Max(0, Math.Min(addition, this.TextArea.ActualWidth - this.Width - client.X));


### PR DESCRIPTION
When using InnovatorAdmin via RDP, this.CompletionList.ScrollViewer is NULL in AutoGrow().
Added a check to work around that.