### PR TITLE
Add Copy actions to the menu, copy with or without headers

### DIFF
--- a/InnovatorAdmin/Ide/EditorWindow.Designer.cs
+++ b/InnovatorAdmin/Ide/EditorWindow.Designer.cs
@@ -146,6 +146,9 @@
       this.mniTableEditsToClipboard = new System.Windows.Forms.ToolStripMenuItem();
       this.mniTableEditsToFile = new System.Windows.Forms.ToolStripMenuItem();
       this.mniTableEditsToQueryEditor = new System.Windows.Forms.ToolStripMenuItem();
+      this.mniTableCopyActions = new System.Windows.Forms.ToolStripMenuItem();
+      this.mniTableCopyWithoutHeader = new System.Windows.Forms.ToolStripMenuItem();
+      this.mniTableCopyWithHeader = new System.Windows.Forms.ToolStripMenuItem();
       this.mniResetChanges = new System.Windows.Forms.ToolStripMenuItem();
       this.btnOk = new InnovatorAdmin.Controls.FlatButton();
       this.btnCancel = new InnovatorAdmin.Controls.FlatButton();
@@ -1369,7 +1372,6 @@
       // 
       this.dgvItems.BackgroundColor = System.Drawing.Color.White;
       this.dgvItems.BorderStyle = System.Windows.Forms.BorderStyle.None;
-      this.dgvItems.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
       this.dgvItems.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
       this.dgvItems.ContextMenuStrip = this.conTable;
       this.dgvItems.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -1387,6 +1389,7 @@
             this.mniColumns,
             this.mniSaveTableEdits,
             this.mniScriptEdits,
+            this.mniTableCopyActions,
             this.mniResetChanges});
       this.conTable.Name = "conTable";
       this.conTable.Size = new System.Drawing.Size(152, 92);
@@ -1398,12 +1401,40 @@
       this.mniColumns.Size = new System.Drawing.Size(151, 22);
       this.mniColumns.Text = "Columns...";
       this.mniColumns.Click += new System.EventHandler(this.mniColumns_Click);
+
+      // 
+      // mniTableCopyActions
+      // 
+      this.mniTableCopyActions.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.mniTableCopyWithoutHeader,
+            this.mniTableCopyWithHeader});
+      this.mniTableCopyActions.Name = "mniTableCopyActions";
+      this.mniTableCopyActions.Size = new System.Drawing.Size(151, 22);
+      this.mniTableCopyActions.Text = "Copy ...";
+
+      // 
+      // mniTableCopyWithoutHeader
+      // 
+      this.mniTableCopyWithoutHeader.Name = "mniTableCopyWithoutHeader";
+      this.mniTableCopyWithoutHeader.Size = new System.Drawing.Size(140, 22);
+      this.mniTableCopyWithoutHeader.Text = "Without Header";
+      this.mniTableCopyWithoutHeader.ShortcutKeyDisplayString = "Ctrl+C";
+      this.mniTableCopyWithoutHeader.Click += new System.EventHandler(this.mniTableCopyWithoutHeader_Click);
+
+      // 
+      // mniTableCopyWithHeader
+      // 
+      this.mniTableCopyWithHeader.Name = "mniTableCopyWithHeader";
+      this.mniTableCopyWithHeader.Size = new System.Drawing.Size(140, 22);
+      this.mniTableCopyWithHeader.Text = "With Header";
+      this.mniTableCopyWithHeader.Click += new System.EventHandler(this.mniTableCopyWithHeader_Click);
+
       // 
       // mniSaveTableEdits
       // 
       this.mniSaveTableEdits.Name = "mniSaveTableEdits";
       this.mniSaveTableEdits.Size = new System.Drawing.Size(151, 22);
-      this.mniSaveTableEdits.Text = "Save";
+      this.mniSaveTableEdits.Text = "Save Edits";
       this.mniSaveTableEdits.Click += new System.EventHandler(this.mniSave_Click);
       // 
       // mniScriptEdits
@@ -1414,7 +1445,7 @@
             this.mniTableEditsToQueryEditor});
       this.mniScriptEdits.Name = "mniScriptEdits";
       this.mniScriptEdits.Size = new System.Drawing.Size(151, 22);
-      this.mniScriptEdits.Text = "Save To";
+      this.mniScriptEdits.Text = "Save Edits To";
       // 
       // mniTableEditsToClipboard
       // 
@@ -1686,6 +1717,9 @@
     private System.Windows.Forms.ContextMenuStrip conTable;
     private System.Windows.Forms.ToolStripMenuItem mniScriptEdits;
     private System.Windows.Forms.ToolStripMenuItem mniTableEditsToQueryEditor;
+    private System.Windows.Forms.ToolStripMenuItem mniTableCopyActions;
+    private System.Windows.Forms.ToolStripMenuItem mniTableCopyWithHeader;
+    private System.Windows.Forms.ToolStripMenuItem mniTableCopyWithoutHeader;
     private System.Windows.Forms.ToolStripMenuItem mniTableEditsToClipboard;
     private System.Windows.Forms.ToolStripMenuItem mniTableEditsToFile;
     private System.Windows.Forms.ToolStripMenuItem mniResetChanges;

--- a/InnovatorAdmin/Ide/EditorWindow.cs
+++ b/InnovatorAdmin/Ide/EditorWindow.cs
@@ -1516,6 +1516,45 @@ namespace InnovatorAdmin
         }
       }
     }
+    #region Copy Actions
+
+    private void mniTableCopyWithoutHeader_Click(object sender, EventArgs e)
+    {
+      try
+      {
+        var grid = tbcOutputView.SelectedTab.Controls.OfType<DataGridView>().Single();
+        DataGridViewClipboardCopyMode oldMode = grid.ClipboardCopyMode;
+        grid.ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableWithoutHeaderText;
+        Clipboard.SetDataObject(grid.GetClipboardContent());
+        grid.ClipboardCopyMode = oldMode;
+      }
+      catch (Exception ex)
+      {
+        Utils.HandleError(ex);
+      }
+    }
+
+    private void mniTableCopyWithHeader_Click(object sender, EventArgs e)
+    {
+      try
+      {
+        var grid = tbcOutputView.SelectedTab.Controls.OfType<DataGridView>().Single();
+        DataGridViewClipboardCopyMode oldMode = grid.ClipboardCopyMode;
+        bool oldHeaders = grid.RowHeadersVisible;
+        grid.RowHeadersVisible = false;
+        grid.ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+        Clipboard.SetDataObject(grid.GetClipboardContent());
+        grid.ClipboardCopyMode = oldMode;
+        grid.RowHeadersVisible = oldHeaders;
+
+      }
+      catch (Exception ex)
+      {
+        Utils.HandleError(ex);
+      }
+    }
+
+    #endregion
 
     #region Table Handling
 
@@ -2057,6 +2096,9 @@ namespace InnovatorAdmin
           conTable.Items.Add(new ToolStripSeparator());
         conTable.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
           this.mniColumns,
+          new ToolStripSeparator(),
+          this.mniTableCopyActions,
+          new ToolStripSeparator(),
           this.mniSaveTableEdits,
           this.mniScriptEdits,
           this.mniResetChanges});


### PR DESCRIPTION
I reverted pull Request #183, because it was annoying to always include the header when copying from the table.
Instead I added two actions to the menu to copy with or without header (and renamed "Save" and "Save to" to "Save Edits"/"Save Edits to"

Revert "Issue #9 : Add the headers when copying from the table"

This reverts commit b175b6f9018dded958b16bd5b28929926c0daba1.