### PR TITLE
Fix 190: Allow to save the result into a file #190

### DIFF
--- a/InnovatorAdmin/Ide/EditorWindow.Designer.cs
+++ b/InnovatorAdmin/Ide/EditorWindow.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace InnovatorAdmin
+namespace InnovatorAdmin
 {
   partial class EditorWindow
   {
@@ -145,6 +145,8 @@
       this.conTable = new System.Windows.Forms.ContextMenuStrip(this.components);
       this.mniColumns = new System.Windows.Forms.ToolStripMenuItem();
       this.mniSaveTableEdits = new System.Windows.Forms.ToolStripMenuItem();
+
+      this.mniSaveTableToFile = new System.Windows.Forms.ToolStripMenuItem();
       this.mniScriptEdits = new System.Windows.Forms.ToolStripMenuItem();
       this.mniTableEditsToClipboard = new System.Windows.Forms.ToolStripMenuItem();
       this.mniTableEditsToFile = new System.Windows.Forms.ToolStripMenuItem();
@@ -1383,6 +1385,7 @@
       this.conTable.ImageScalingSize = new System.Drawing.Size(32, 32);
       this.conTable.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.mniColumns,
+            this.mniSaveTableToFile,
             this.mniSaveTableEdits,
             this.mniScriptEdits,
             this.mniTableCopyActions,
@@ -1428,6 +1431,15 @@
       this.mniTableEditsToFile.Size = new System.Drawing.Size(140, 22);
       this.mniTableEditsToFile.Text = "File...";
       this.mniTableEditsToFile.Click += new System.EventHandler(this.mniTableEditsToFile_Click);
+
+      //
+      // mniResultsToFile
+      //
+      this.mniSaveTableToFile.Name = "mniTableToFile_Click";
+      this.mniSaveTableToFile.Size = new System.Drawing.Size(140, 22);
+      this.mniSaveTableToFile.Text = "Save Table To File";
+      this.mniSaveTableToFile.Click += new System.EventHandler(this.mniTableToFile_Click);
+
       // 
       // mniTableEditsToQueryEditor
       // 
@@ -1807,6 +1819,7 @@
     private System.Windows.Forms.Panel pnlRightTop;
     private DropShadow pnlConnectionShadow;
     private System.Windows.Forms.ToolStripMenuItem mniSaveTableEdits;
+    private System.Windows.Forms.ToolStripMenuItem mniSaveTableToFile;
     private System.Windows.Forms.ToolStripMenuItem mniOpen;
     private System.Windows.Forms.ToolStripMenuItem mniSave;
     private System.Windows.Forms.Label lblClock;

--- a/InnovatorAdmin/Ide/EditorWindow.cs
+++ b/InnovatorAdmin/Ide/EditorWindow.cs
@@ -1,4 +1,4 @@
-﻿using ICSharpCode.AvalonEdit.Document;
+using ICSharpCode.AvalonEdit.Document;
 using Innovator.Client;
 using Innovator.Client.Connection;
 using InnovatorAdmin.Connections;
@@ -1648,7 +1648,56 @@ namespace InnovatorAdmin
         Utils.HandleError(ex);
       }
     }
+    private void mniTableToFile_Click(object sender, EventArgs e)
+    {
+      try
+      {
+        using (var dialog = new SaveFileDialog())
+        {
+          if (dialog.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+          {
+                var grid = tbcOutputView.SelectedTab.Controls.OfType<DataGridView>().Single();
+                DataGridViewClipboardCopyMode oldMode = grid.ClipboardCopyMode;
+                bool oldHeaders = grid.RowHeadersVisible;
+                grid.RowHeadersVisible = true;
+                grid.ClipboardCopyMode = DataGridViewClipboardCopyMode.EnableAlwaysIncludeHeaderText;
+                grid.RowHeadersVisible = oldHeaders;
 
+            //System.IO.File.WriteAllText(dialog.FileName, grid.to);
+         
+              int columnCount = grid.Columns.Count;
+                string columnNames = "";
+                string outputCsv ="";
+
+            using (System.IO.StreamWriter file =
+                  new System.IO.StreamWriter(dialog.FileName))
+            {
+              for (int i = 0; i < columnCount; i++)
+              {
+                columnNames += grid.Columns[i].HeaderText.ToString() + "\t";
+              }
+              outputCsv += columnNames;
+              file.WriteLine(outputCsv);
+              outputCsv = "";
+              for (int i = 1; (i - 1) < grid.Rows.Count; i++)
+              {
+                for (int j = 0; j < columnCount; j++)
+                {
+                  outputCsv += grid.Rows[i - 1].Cells[j].Value.ToString() + "\t";
+                }
+                file.WriteLine(outputCsv);
+                outputCsv = "";
+              }
+
+            }   
+          }
+        }
+      }
+      catch (Exception ex)
+      {
+        Utils.HandleError(ex);
+      }
+    }
     private void mniTableEditsToQueryEditor_Click(object sender, EventArgs e)
     {
       try
@@ -2152,6 +2201,8 @@ namespace InnovatorAdmin
           this.mniColumns,
           new ToolStripSeparator(),
           this.mniTableCopyActions,
+          new ToolStripSeparator(),
+          this.mniSaveTableToFile,
           new ToolStripSeparator(),
           this.mniSaveTableEdits,
           this.mniScriptEdits,


### PR DESCRIPTION
Adds a new action to save the results to a file. The file will contain the columns separated by a TAB character.
