### PR TITLE
Fix 210: Prevent a double click on title to copy into clipboard

### DIFF
--- a/InnovatorAdmin/ConnectionEditorForm.Designer.cs
+++ b/InnovatorAdmin/ConnectionEditorForm.Designer.cs
@@ -33,7 +33,7 @@
       this.btnClose = new InnovatorAdmin.Controls.FlatButton();
       this.connectionEditor = new InnovatorAdmin.ConnectionEditor();
       this.btnOk = new InnovatorAdmin.Controls.FlatButton();
-      this.lblTitle = new System.Windows.Forms.Label();
+      this.lblTitle = new InnovatorAdmin.Controls.NoCopyLabel();
       this.pnlTopLeft = new System.Windows.Forms.Panel();
       this.pnlTop = new System.Windows.Forms.Panel();
       this.pnlLeft = new System.Windows.Forms.Panel();

--- a/InnovatorAdmin/Controls/NoCopyLabel.cs
+++ b/InnovatorAdmin/Controls/NoCopyLabel.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+//
+// Helper class to prevent copying the Title into the clipboard on double click / maximize
+//
+namespace InnovatorAdmin.Controls
+{
+  class NoCopyLabel : Label
+  {
+    private const int WM_LBUTTONDBLCLK = 0x203;
+
+    protected override void WndProc(ref Message m)
+    {
+      if (m.Msg == WM_LBUTTONDBLCLK)
+      {
+        string sSaved = Clipboard.GetText();
+        System.Drawing.Image iSaved = Clipboard.GetImage();
+        base.WndProc(ref m);
+        if (iSaved != null) Clipboard.SetImage(iSaved);
+        if (!string.IsNullOrEmpty(sSaved)) Clipboard.SetText(sSaved);
+      }
+      else
+      {
+        base.WndProc(ref m);
+      }
+    }
+  }
+}

--- a/InnovatorAdmin/Dialog/ColorDialog.Designer.cs
+++ b/InnovatorAdmin/Dialog/ColorDialog.Designer.cs
@@ -38,7 +38,7 @@
       this.pnlTopRight = new System.Windows.Forms.Panel();
       this.pnlBottomLeft = new System.Windows.Forms.Panel();
       this.pnlBottomRight = new System.Windows.Forms.Panel();
-      this.lblTitle = new System.Windows.Forms.Label();
+      this.lblTitle = new InnovatorAdmin.Controls.NoCopyLabel();
       this.pnlLeft = new System.Windows.Forms.Panel();
       this.pnlRight = new System.Windows.Forms.Panel();
       this.panel1 = new System.Windows.Forms.Panel();

--- a/InnovatorAdmin/Ide/EditorWindow.Designer.cs
+++ b/InnovatorAdmin/Ide/EditorWindow.Designer.cs
@@ -33,7 +33,7 @@
       this.tblMain = new System.Windows.Forms.TableLayoutPanel();
       this.tblHeader = new System.Windows.Forms.TableLayoutPanel();
       this.lblClose = new System.Windows.Forms.Label();
-      this.lblTitle = new System.Windows.Forms.Label();
+      this.lblTitle = new InnovatorAdmin.Controls.NoCopyLabel();
       this.menuStrip = new System.Windows.Forms.ToolStrip();
       this.lblConnection = new System.Windows.Forms.ToolStripLabel();
       this.btnEditConnections = new System.Windows.Forms.ToolStripButton();

--- a/InnovatorAdmin/InnovatorAdmin.csproj
+++ b/InnovatorAdmin/InnovatorAdmin.csproj
@@ -204,6 +204,9 @@
     <Compile Include="Controls\MergeInterface.Designer.cs">
       <DependentUpon>MergeInterface.cs</DependentUpon>
     </Compile>
+    <Compile Include="Controls\NoCopyLabel.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Controls\ParameterGrid.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/InnovatorAdmin/Main.Designer.cs
+++ b/InnovatorAdmin/Main.Designer.cs
@@ -35,7 +35,7 @@
       this.tblMain = new System.Windows.Forms.TableLayoutPanel();
       this.tblHeader = new System.Windows.Forms.TableLayoutPanel();
       this.lblClose = new System.Windows.Forms.Label();
-      this.lblTitle = new System.Windows.Forms.Label();
+      this.lblTitle = new InnovatorAdmin.Controls.NoCopyLabel();
       this.lblMaximize = new System.Windows.Forms.Label();
       this.lblMinimize = new System.Windows.Forms.Label();
       this.picLogo = new System.Windows.Forms.PictureBox();


### PR DESCRIPTION
Implemented a Label subclass to prevent maximizing a window via double click to copy its title into the ClipBoard